### PR TITLE
Bump build number to trigger rebuild with non-buggy conda-build version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vvv
 
 requirements:


### PR DESCRIPTION
Currently (v0.5.3) this package includes 5MB of pip-installed dependencies. This is due to a short-lived bug in conda-build 3.16, fixed in 3.17.0. (https://github.com/conda/conda-build/issues/3254)
Some details at a similar issue: https://github.com/conda-forge/bleach-feedstock/issues/17

Conda-forge is now using conda-buid 3.17, so this package should be rebuilt.
cc @minrk
